### PR TITLE
Allow configuration of the scheduled executor

### DIFF
--- a/src/main/java/com/qmetric/feed/consumer/FeedConsumerConfiguration.java
+++ b/src/main/java/com/qmetric/feed/consumer/FeedConsumerConfiguration.java
@@ -18,6 +18,8 @@ import org.joda.time.DateTime;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -60,6 +62,10 @@ public class FeedConsumerConfiguration
     private Optional<ResourceResolver> resourceResolver = Optional.absent();
 
     private Optional<Integer> maxRetries = Optional.absent();
+
+    private boolean registerShutdownHook = true;
+
+    private ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
 
     public FeedConsumerConfiguration(final String name)
     {
@@ -164,6 +170,20 @@ public class FeedConsumerConfiguration
         return this;
     }
 
+    public FeedConsumerConfiguration registerShutdownHook(boolean registerShutdownHook)
+    {
+        this.registerShutdownHook = registerShutdownHook;
+
+        return this;
+    }
+
+    public FeedConsumerConfiguration withScheduledExecutorService(ScheduledExecutorService scheduledExecutorService)
+    {
+        this.scheduledExecutorService = scheduledExecutorService;
+
+        return this;
+    }
+
     public HealthCheckRegistry getHealthCheckRegistry()
     {
         return healthCheckRegistry;
@@ -185,7 +205,7 @@ public class FeedConsumerConfiguration
 
     private FeedConsumerScheduler buildConsumerScheduler()
     {
-        return new FeedConsumerScheduler(feedConsumer(), feedEntriesFinder(), pollingInterval);
+        return new FeedConsumerScheduler(feedConsumer(), feedEntriesFinder(), pollingInterval, scheduledExecutorService, registerShutdownHook);
     }
 
     private AvailableFeedEntriesFinder feedEntriesFinder()

--- a/src/test/groovy/com/qmetric/feed/consumer/FeedConsumerConfigurationTest.groovy
+++ b/src/test/groovy/com/qmetric/feed/consumer/FeedConsumerConfigurationTest.groovy
@@ -9,6 +9,7 @@ import com.sun.jersey.api.client.filter.HTTPBasicAuthFilter
 import org.joda.time.DateTime
 import spock.lang.Specification
 
+import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 
 @SuppressWarnings("GroovyAccessibility")
@@ -172,5 +173,29 @@ class FeedConsumerConfigurationTest extends Specification {
 
         then:
         feedConsumerConfiguration.resourceResolver == Optional.of(resourceResolver)
+    }
+
+    def "should accept overridden scheduled executor service"()
+    {
+        given:
+        final executorService = Mock(ScheduledExecutorService)
+
+        when:
+        feedConsumerConfiguration.withScheduledExecutorService(executorService)
+
+        then:
+        feedConsumerConfiguration.scheduledExecutorService == executorService;
+    }
+
+    def "should accept register shutdown hook"()
+    {
+        given:
+        final registerShutdownHook = false
+
+        when:
+        feedConsumerConfiguration.registerShutdownHook(registerShutdownHook)
+
+        then:
+        feedConsumerConfiguration.registerShutdownHook == registerShutdownHook
     }
 }

--- a/src/test/groovy/com/qmetric/feed/consumer/FeedConsumerSchedulerTest.groovy
+++ b/src/test/groovy/com/qmetric/feed/consumer/FeedConsumerSchedulerTest.groovy
@@ -14,7 +14,7 @@ class FeedConsumerSchedulerTest extends Specification {
     final consumer = Mock(FeedConsumerImpl)
     final finder = Mock(AvailableFeedEntriesFinder)
 
-    final scheduler = new FeedConsumerScheduler(consumer, finder, interval, scheduledExecutionService)
+    final scheduler = new FeedConsumerScheduler(consumer, finder, interval, scheduledExecutionService, true)
 
     def "should periodically consume feed"()
     {


### PR DESCRIPTION
@huwtl @spaceCamel 

I'm proposing this change because I want to be able to provide the client with an 'already configured' `ScheduledExecutorService`. 

When providing an executor I also want to manage the lifecycle of the executor myself so I have added an option to disable registration of the `ShutdownProcedure` as a shutdown hook.