### PR TITLE
Check environmental properties consistently in tests and build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,30 @@
                     <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4</version>
+                <executions>
+                    <execution>
+                        <id>enforce-test-environment-variables-are-set</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <rules>
+                        <requireEnvironmentVariable>
+                            <variableName>HAL_CONSUMER_IT_AWS_ACCESS_KEY</variableName>
+                        </requireEnvironmentVariable>
+                        <requireEnvironmentVariable>
+                            <variableName>HAL_CONSUMER_IT_AWS_SECRET_KEY</variableName>
+                        </requireEnvironmentVariable>
+                    </rules>
+                    <fail>true</fail>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/test/groovy/com/qmetric/feed/consumer/IntegrationTest.groovy
+++ b/src/test/groovy/com/qmetric/feed/consumer/IntegrationTest.groovy
@@ -12,23 +12,24 @@ import org.junit.BeforeClass
 import org.junit.Test
 import spark.Spark
 
-import static com.google.common.base.Preconditions.checkState
 import static com.qmetric.feed.consumer.DomainNameFactory.userPrefixedDomainName
-import static java.lang.System.getenv
+import static com.qmetric.feed.consumer.utils.TestEnvironment.accessKey
+import static com.qmetric.feed.consumer.utils.TestEnvironment.secretKey
+import static com.qmetric.feed.consumer.utils.TestEnvironment.verifyEnvironment
 import static java.util.concurrent.TimeUnit.SECONDS
-import static org.apache.commons.lang3.StringUtils.isBlank
 import static org.hamcrest.CoreMatchers.equalTo
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Matchers.any
-import static org.mockito.Mockito.*
+import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.times
+import static org.mockito.Mockito.verify
+import static org.mockito.Mockito.when
 
 class IntegrationTest {
     private static final FEED_SIZE = 9
     private static final PAGE_SIZE = 3
     private static final FEED_SERVER_PORT = 15000
     private static final DOMAIN_NAME = userPrefixedDomainName('hal-feed-consumer-test')
-    private final String accessKey = getenv('HAL_CONSUMER_IT_AWS_ACCESS_KEY')
-    private final String secretKey = getenv('HAL_CONSUMER_IT_AWS_SECRET_KEY')
     private final AmazonSimpleDBClient simpleDBClient
     private final SimpleDBUtils simpleDBUtils
     private final FeedTracker tracker
@@ -39,9 +40,8 @@ class IntegrationTest {
 
     public IntegrationTest()
     {
-        checkState(!isBlank(accessKey), 'Missing env variable %s', 'HAL_CONSUMER_IT_AWS_ACCESS_KEY')
-        checkState(!isBlank(accessKey), 'Missing env variable %s', 'HAL_CONSUMER_IT_AWS_SECRET_KEY')
-        simpleDBClient = new SimpleDBClientFactory(accessKey, secretKey).simpleDBClient()
+        verifyEnvironment()
+        simpleDBClient = new SimpleDBClientFactory(accessKey(), secretKey()).simpleDBClient()
         simpleDBUtils = new SimpleDBUtils(simpleDBClient)
         tracker = new SimpleDBFeedTracker(simpleDBClient, DOMAIN_NAME)
         consumer = new FeedConsumerConfiguration("test-feed")

--- a/src/test/groovy/com/qmetric/feed/consumer/MultipleClientTest.groovy
+++ b/src/test/groovy/com/qmetric/feed/consumer/MultipleClientTest.groovy
@@ -10,13 +10,16 @@ import com.theoryinpractise.halbuilder.api.RepresentationFactory
 import com.theoryinpractise.halbuilder.impl.representations.MutableRepresentation
 import org.junit.After
 import org.junit.Before
+import org.junit.BeforeClass
 import org.junit.Test
 
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
 
 import static com.qmetric.feed.consumer.DomainNameFactory.userPrefixedDomainName
-import static java.lang.System.getenv
+import static com.qmetric.feed.consumer.utils.TestEnvironment.accessKey
+import static com.qmetric.feed.consumer.utils.TestEnvironment.secretKey
+import static com.qmetric.feed.consumer.utils.TestEnvironment.verifyEnvironment
 import static java.lang.Thread.currentThread
 import static java.util.Collections.emptyList
 import static java.util.concurrent.TimeUnit.SECONDS
@@ -27,9 +30,9 @@ import static org.mockito.Mockito.mock
 class MultipleClientTest {
     private static final FEED_SIZE = 9
     private static final String MARKER = 'throw-exception'
-    private static final AmazonSimpleDBClient client = new SimpleDBClientFactory(getenv('HAL_CONSUMER_IT_AWS_ACCESS_KEY'), getenv('HAL_CONSUMER_IT_AWS_SECRET_KEY')).simpleDBClient()
+    private static AmazonSimpleDBClient client
+    private static SimpleDBFeedTracker tracker
     private static final String DOMAIN_NAME = userPrefixedDomainName('hal-feed-consumer-test')
-    private static final SimpleDBFeedTracker tracker = new SimpleDBFeedTracker(client, DOMAIN_NAME)
     private static final executor = Executors.newFixedThreadPool(2)
     private static final resolver = new ResourceResolver() {
         @Override HalResource resolve(final EntryId id)
@@ -37,6 +40,13 @@ class MultipleClientTest {
             def representation = new HalResource(new ObjectMapper(), new MutableRepresentation(mock(RepresentationFactory), "/${id.toString()}"))
             return representation
         }
+    }
+
+    @BeforeClass public static void setupFeedTracker()
+    {
+        verifyEnvironment()
+        client = new SimpleDBClientFactory(accessKey(), secretKey()).simpleDBClient()
+        tracker = new SimpleDBFeedTracker(client, DOMAIN_NAME)
     }
 
     @Before public void setupDomain()

--- a/src/test/groovy/com/qmetric/feed/consumer/utils/TestEnvironment.groovy
+++ b/src/test/groovy/com/qmetric/feed/consumer/utils/TestEnvironment.groovy
@@ -1,0 +1,28 @@
+package com.qmetric.feed.consumer.utils
+
+import static com.google.common.base.Preconditions.checkState
+import static java.lang.System.getenv
+import static org.apache.commons.lang3.StringUtils.isBlank
+
+class TestEnvironment
+{
+    private static final String ACCESS_KEY_PROPERTY = 'HAL_CONSUMER_IT_AWS_ACCESS_KEY'
+
+    private static final String SECRET_KEY_PROPERTY = 'HAL_CONSUMER_IT_AWS_SECRET_KEY'
+
+    static void verifyEnvironment()
+    {
+        checkState(!isBlank(accessKey()), 'Missing env variable %s', ACCESS_KEY_PROPERTY)
+        checkState(!isBlank(secretKey()), 'Missing env variable %s', SECRET_KEY_PROPERTY)
+    }
+
+    static accessKey()
+    {
+        getenv(ACCESS_KEY_PROPERTY)
+    }
+
+    static secretKey()
+    {
+        getenv(SECRET_KEY_PROPERTY)
+    }
+}


### PR DESCRIPTION
Added a utility to consistently check and access environmental properties for tests that require them.

Additionally added build-level checks that fail the build when environmental properties are missing. 

The build failure instructs the user what is missing, e.g.:

    [INFO] --- maven-enforcer-plugin:1.4:enforce (enforce-maven) @ hal-feed-consumer ---
    [WARNING] Rule 1: org.apache.maven.plugins.enforcer.RequireEnvironmentVariable failed with message:
    Environment variable "HAL_CONSUMER_IT_AWS_ACCESS_KEY" is required for this build.
    [WARNING] Rule 2: org.apache.maven.plugins.enforcer.RequireEnvironmentVariable failed with message:
    Environment variable "HAL_CONSUMER_IT_AWS_SECRET_KEY" is required for this build.

As a new contributor it wasn't immediately obvious to me why the build was failing. Hopefully these changes will help others in future.