### PR TITLE
Upgrade to JAX-RS 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,9 +65,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.sun.jersey</groupId>
+            <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>1.17.1</version>
+            <version>2.17</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/qmetric/feed/consumer/FeedConsumerConfiguration.java
+++ b/src/main/java/com/qmetric/feed/consumer/FeedConsumerConfiguration.java
@@ -12,10 +12,11 @@ import com.qmetric.feed.consumer.metrics.FeedTrackerConnectivityHealthCheck;
 import com.qmetric.feed.consumer.metrics.PollingActivityHealthCheck;
 import com.qmetric.feed.consumer.store.FeedTracker;
 import com.qmetric.hal.reader.HalReader;
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.filter.HTTPBasicAuthFilter;
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
 import org.joda.time.DateTime;
 
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.Executors;
@@ -35,7 +36,7 @@ public class FeedConsumerConfiguration
 
     private final Collection<EntryConsumerListener> entryConsumerListeners = new ArrayList<EntryConsumerListener>();
 
-    private final Client feedClient = new Client();
+    private final Client feedClient = ClientBuilder.newBuilder().build();
 
     private final FeedEndpointFactory feedEndpointFactory = new FeedEndpointFactory(feedClient, new FeedEndpointFactory.ConnectionTimeout(MINUTES, 1));
 
@@ -130,7 +131,10 @@ public class FeedConsumerConfiguration
 
     public FeedConsumerConfiguration withAuthenticationCredentials(final Credentials credentials)
     {
-        feedClient.addFilter(new HTTPBasicAuthFilter(credentials.username, credentials.password));
+        final HttpAuthenticationFeature httpAuthFeature = HttpAuthenticationFeature.basicBuilder()
+                .credentials(credentials.username, credentials.password)
+                .build();
+        feedClient.register(httpAuthFeature);
 
         return this;
     }

--- a/src/main/java/com/qmetric/feed/consumer/FeedEndpoint.java
+++ b/src/main/java/com/qmetric/feed/consumer/FeedEndpoint.java
@@ -1,37 +1,42 @@
 package com.qmetric.feed.consumer;
 
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.WebResource;
 
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 
 import static com.google.common.base.Preconditions.checkState;
-import static com.sun.jersey.api.client.ClientResponse.Status.OK;
 import static com.theoryinpractise.halbuilder.api.RepresentationFactory.HAL_JSON;
+import static javax.ws.rs.core.Response.Status.OK;
 
 public class FeedEndpoint
 {
-    private final WebResource resource;
+    private final WebTarget target;
 
-    public FeedEndpoint(final WebResource resource)
+    public FeedEndpoint(final WebTarget target)
     {
-        this.resource = resource;
+        this.target = target;
     }
 
     public Reader get()
     {
-        return new InputStreamReader(getClientResponse().getEntityInputStream());
+        return new InputStreamReader(getResponse().readEntity(InputStream.class));
     }
 
-    private ClientResponse getClientResponse()
+    private Response getResponse()
     {
-        final ClientResponse clientResponse = resource.accept(HAL_JSON).get(ClientResponse.class);
-        check(clientResponse.getClientResponseStatus());
-        return clientResponse;
+        final Response response = target.request(HAL_JSON)
+                .get();
+
+        final Response.Status status = Response.Status.fromStatusCode(response.getStatus());
+        check(status);
+
+        return response;
     }
 
-    private void check(final ClientResponse.Status status)
+    private void check(final Response.Status status)
     {
         checkState(status == OK, "Endpoint returned [%s: %s]", status.getStatusCode(), status.getReasonPhrase());
     }

--- a/src/main/java/com/qmetric/feed/consumer/FeedEndpointFactory.java
+++ b/src/main/java/com/qmetric/feed/consumer/FeedEndpointFactory.java
@@ -1,7 +1,8 @@
 package com.qmetric.feed.consumer;
 
-import com.sun.jersey.api.client.Client;
+import org.glassfish.jersey.client.ClientProperties;
 
+import javax.ws.rs.client.Client;
 import java.util.concurrent.TimeUnit;
 
 public class FeedEndpointFactory
@@ -16,13 +17,13 @@ public class FeedEndpointFactory
 
     private void initClient(final ConnectionTimeout timeout)
     {
-        client.setConnectTimeout(timeout.asMillis());
-        client.setReadTimeout(timeout.asMillis());
+        client.property(ClientProperties.CONNECT_TIMEOUT, timeout.asMillis());
+        client.property(ClientProperties.READ_TIMEOUT, timeout.asMillis());
     }
 
     public FeedEndpoint create(final String url)
     {
-        return new FeedEndpoint(client.resource(url));
+        return new FeedEndpoint(client.target(url));
     }
 
     public static class ConnectionTimeout

--- a/src/main/java/com/qmetric/feed/consumer/metrics/FeedConnectivityHealthCheck.java
+++ b/src/main/java/com/qmetric/feed/consumer/metrics/FeedConnectivityHealthCheck.java
@@ -1,9 +1,9 @@
 package com.qmetric.feed.consumer.metrics;
 
 import com.codahale.metrics.health.HealthCheck;
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
+import org.glassfish.jersey.client.ClientResponse;
 
+import javax.ws.rs.client.Client;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -27,7 +27,7 @@ public class FeedConnectivityHealthCheck extends HealthCheck
 
     @Override protected Result check() throws Exception
     {
-        final ClientResponse clientResponse = client.resource(feedPingUrl).accept(HAL_JSON).get(ClientResponse.class);
+        final ClientResponse clientResponse = client.target(feedPingUrl).request(HAL_JSON).get(ClientResponse.class);
 
         if (clientResponse.getStatus() == HTTP_OK)
         {

--- a/src/test/groovy/com/qmetric/feed/consumer/FeedConsumerConfigurationTest.groovy
+++ b/src/test/groovy/com/qmetric/feed/consumer/FeedConsumerConfigurationTest.groovy
@@ -5,7 +5,7 @@ import com.codahale.metrics.health.HealthCheckRegistry
 import com.google.common.base.Optional
 import com.qmetric.feed.consumer.store.FeedTracker
 import com.qmetric.hal.reader.HalReader
-import com.sun.jersey.api.client.filter.HTTPBasicAuthFilter
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature
 import org.joda.time.DateTime
 import spock.lang.Specification
 
@@ -53,7 +53,7 @@ class FeedConsumerConfigurationTest extends Specification {
         feedConsumerConfiguration.withAuthenticationCredentials(new FeedConsumerConfiguration.Credentials("user", "password".bytes))
 
         then:
-        feedConsumerConfiguration.feedClient.getHeadHandler() instanceof HTTPBasicAuthFilter
+        feedConsumerConfiguration.feedClientBuilder.getConfiguration().isRegistered(HttpAuthenticationFeature)
     }
 
     def "should accept feed tracker"()

--- a/src/test/groovy/com/qmetric/feed/consumer/FeedConsumerConfigurationTest.groovy
+++ b/src/test/groovy/com/qmetric/feed/consumer/FeedConsumerConfigurationTest.groovy
@@ -53,7 +53,7 @@ class FeedConsumerConfigurationTest extends Specification {
         feedConsumerConfiguration.withAuthenticationCredentials(new FeedConsumerConfiguration.Credentials("user", "password".bytes))
 
         then:
-        feedConsumerConfiguration.feedClientBuilder.getConfiguration().isRegistered(HttpAuthenticationFeature)
+        feedConsumerConfiguration.feedClient.getConfiguration().isRegistered(HttpAuthenticationFeature)
     }
 
     def "should accept feed tracker"()

--- a/src/test/groovy/com/qmetric/feed/consumer/metrics/FeedConnectivityHealthCheckTest.groovy
+++ b/src/test/groovy/com/qmetric/feed/consumer/metrics/FeedConnectivityHealthCheckTest.groovy
@@ -1,18 +1,20 @@
 package com.qmetric.feed.consumer.metrics
 
-import com.sun.jersey.api.client.Client
-import com.sun.jersey.api.client.ClientResponse
-import com.sun.jersey.api.client.WebResource
 import com.theoryinpractise.halbuilder.api.RepresentationFactory
+import org.glassfish.jersey.client.ClientResponse
 import spock.lang.Specification
+
+import javax.ws.rs.client.Client
+import javax.ws.rs.client.Invocation
+import javax.ws.rs.client.WebTarget
 
 class FeedConnectivityHealthCheckTest extends Specification {
 
     final client = Mock(Client)
 
-    final webResource = Mock(WebResource)
+    final webTarget = Mock(WebTarget)
 
-    final webResourceBuilder = Mock(WebResource.Builder)
+    final invocationBuilder = Mock(Invocation.Builder)
 
     final response = Mock(ClientResponse)
 
@@ -20,9 +22,9 @@ class FeedConnectivityHealthCheckTest extends Specification {
 
     def setup()
     {
-        client.resource("http://host:123/ping") >> webResource
-        webResource.accept(RepresentationFactory.HAL_JSON) >> webResourceBuilder
-        webResourceBuilder.get(ClientResponse.class) >> response
+        client.target("http://host:123/ping") >> webTarget
+        webTarget.request(RepresentationFactory.HAL_JSON) >> invocationBuilder
+        invocationBuilder.get(ClientResponse.class) >> response
     }
 
     def "should know when feed connectivity is healthy"()


### PR DESCRIPTION
This change resolves an issue we are experiencing with Jersey 1 clashing with v2. 

Jersey 2 uses [a dependency injection framework][1] which this registers things like `MessageBodyReader`s automatically. This registration is attempting to configure Jersey 1 classes and this is causing the error.

I thought I would try upgrading the feed consumer to use Jersey 2 as JAX-RS 2 is well established. 

Let me know what you think.

[1]: https://hk2.java.net/2.4.0-b16/