### PR TITLE
Retry strategy is now configurable.

### DIFF
--- a/src/main/java/com/qmetric/feed/consumer/Interval.java
+++ b/src/main/java/com/qmetric/feed/consumer/Interval.java
@@ -25,6 +25,10 @@ public class Interval
         return TimeUnit.MILLISECONDS.convert(time, unit);
     }
 
+    public Interval times(int factor) {
+        return new Interval(time * factor, unit);
+    }
+
     @Override
     public boolean equals(final Object obj)
     {

--- a/src/main/java/com/qmetric/feed/consumer/retry/FibonacciDelayingRetryStrategy.java
+++ b/src/main/java/com/qmetric/feed/consumer/retry/FibonacciDelayingRetryStrategy.java
@@ -1,0 +1,45 @@
+package com.qmetric.feed.consumer.retry;
+
+import com.qmetric.feed.consumer.Interval;
+import org.joda.time.DateTime;
+import java.util.List;
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+
+public class FibonacciDelayingRetryStrategy implements RetryStrategy {
+
+    public final Interval baseInterval;
+
+    private final static List<Integer> FIBONACCI_SEQUENCE = unmodifiableList(asList(0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233));
+
+    public FibonacciDelayingRetryStrategy(Interval baseInterval) {
+        this.baseInterval = baseInterval;
+    }
+
+    @Override
+    public boolean canRetry(final int retriesSoFar, final DateTime timeOfLastOperation, final DateTime currentTime) {
+        if (retriesSoFar <= 0) {
+            return true;
+        } else {
+            DateTime timeAfterWhichNextRetryCanTakePlace = calculateTimeAfterWhichNextRetryCanTakePlace(retriesSoFar, timeOfLastOperation);
+            return currentTime.isAfter(timeAfterWhichNextRetryCanTakePlace);
+        }
+    }
+
+    private DateTime calculateTimeAfterWhichNextRetryCanTakePlace(int retriesSoFar, DateTime timeOfLastOperation) {
+        int delayFactor = calculateDelayFactor(retriesSoFar);
+        return timeOfLastOperation.plus(baseInterval.times(delayFactor).asMillis());
+    }
+
+    private static Integer calculateDelayFactor(int retriesSoFar) {
+        return FIBONACCI_SEQUENCE.get(normalizeRetries(retriesSoFar));
+    }
+
+    private static int normalizeRetries(int retriesSoFar) {
+        int lastIndexFromSequence = FIBONACCI_SEQUENCE.size() - 1;
+        int result = (retriesSoFar >= 0) ? retriesSoFar : 0;
+        result = (result <= lastIndexFromSequence) ? result : lastIndexFromSequence;
+
+        return result;
+    }
+}

--- a/src/test/groovy/com/qmetric/feed/consumer/IntervalTest.groovy
+++ b/src/test/groovy/com/qmetric/feed/consumer/IntervalTest.groovy
@@ -23,4 +23,17 @@ class IntervalTest extends Specification {
         then:
         thrown(RuntimeException)
     }
+
+    def "should create copy of itself multiplied by a given factor"() {
+        given:
+        Interval interval = new Interval(5, TimeUnit.MINUTES)
+        long originalIntervalInMillis = interval.asMillis()
+
+        when:
+        Interval newInterval = interval.times(4)
+
+        then:
+        interval.asMillis() == originalIntervalInMillis
+        newInterval.asMillis() == originalIntervalInMillis * 4
+    }
 }

--- a/src/test/groovy/com/qmetric/feed/consumer/retry/FibonacciDelayingRetryStrategyTest.groovy
+++ b/src/test/groovy/com/qmetric/feed/consumer/retry/FibonacciDelayingRetryStrategyTest.groovy
@@ -1,0 +1,62 @@
+package com.qmetric.feed.consumer.retry
+
+import com.qmetric.feed.consumer.Interval
+import org.joda.time.DateTime
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.util.concurrent.TimeUnit
+
+class FibonacciDelayingRetryStrategyTest extends Specification {
+
+    def "should always allow retry if no retries so far"() {
+        given:
+        int retriesSoFar = 0
+
+        expect:
+        retryStrategy.canRetry(retriesSoFar, someTime, someTime)
+        retryStrategy.canRetry(retriesSoFar, someTime, someTime.plusMinutes(1))
+        retryStrategy.canRetry(retriesSoFar, someTime, someTime.minusMinutes(1))
+    }
+
+    //@spock.lang.Unroll
+    def "should increase interval based on Fibonacci sequence to a certain point, e.g. should wait at least #howManyMinutesShouldWait minutes after #retriesSoFar retries for base interval set to #intervalInMinutes minutes"() {
+        given:
+        DateTime timeOfLastOperation = someTime
+        DateTime momentBeforeExpectedDelay = timeOfLastOperation.plusMinutes(howManyMinutesShouldWait).minusSeconds(1)
+        DateTime momentAfterExpectedDelay = timeOfLastOperation.plusMinutes(howManyMinutesShouldWait).plusSeconds(1)
+
+        expect:
+        ! retryStrategy.canRetry(retriesSoFar, timeOfLastOperation, momentBeforeExpectedDelay)
+        retryStrategy.canRetry(retriesSoFar, timeOfLastOperation, momentAfterExpectedDelay)
+
+        where:
+        retriesSoFar || howManyIntervalsShouldWait
+        1            || 1
+        2            || 1
+        3            || 2
+        4            || 3
+        5            || 5
+        6            || 8
+        7            || 13
+        8            || 21
+        9            || 34
+        10           || 55
+        11           || 89
+        12           || 144
+        13           || 233
+        14           || 233
+        9999         || 233
+
+        howManyMinutesShouldWait = howManyIntervalsShouldWait * baseIntervalInMinutes
+        intervalInMinutes = baseIntervalInMinutes
+    }
+
+    DateTime someTime = DateTime.now()
+    @Shared
+    int baseIntervalInMinutes = 3
+    Interval baseInterval = new Interval(3, TimeUnit.MINUTES)
+    RetryStrategy retryStrategy = new FibonacciDelayingRetryStrategy(baseInterval)
+
+
+}


### PR DESCRIPTION
- FeedConsumerConfiguration::withCustomRetryStrategy allows client to implement its own delay strategy
- FeedConsumerConfiguration::withIncrementallyDelayingRetryStrategy allows client to use a 'smarter' incrementally delaying retry strategy instead of the default one
- The system uses an 'always retry' strategy by default when none specified (i.e. it does NOT change the existing behaviour)